### PR TITLE
Add reference frame support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ v3 = v1 + v2
 v4 = v1 * 2.0
 ```
 
+### Reference Frames
+```python
+from lvec import LVec, Frame
+
+# Create particles in the lab frame
+p1_lab = LVec(px=0.0, py=0.0, pz=20.0, E=25.0)
+p2_lab = LVec(px=0.0, py=0.0, pz=-15.0, E=20.0)
+total_lab = p1_lab + p2_lab
+
+# Create reference frames
+lab_frame = Frame.rest(name="lab")  # Stationary frame
+cm_frame = Frame.from_lvec(total_lab, name="cm")  # Center-of-mass frame
+
+# Transform particles to center-of-mass frame
+p1_cm = p1_lab.transform_frame(lab_frame, cm_frame)
+p2_cm = p2_lab.transform_frame(lab_frame, cm_frame)
+
+# Verify momentum conservation in CM frame
+total_cm = p1_cm + p2_cm
+print(f"Total momentum in CM: ({total_cm.px:.3f}, {total_cm.py:.3f}, {total_cm.pz:.3f})")
+# Should output values close to (0, 0, 0)
+
+# Alternative: directly transform to a frame
+p1_cm_alt = p1_lab.to_frame(cm_frame)
+```
+
 ### 2D Vectors
 ```python
 from lvec import Vector2D
@@ -105,12 +131,23 @@ vectors_ak = LVec(ak.Array(px), ak.Array(py), ak.Array(pz), ak.Array(E))
 | `from_ary` | Create from dictionary | `ary_dict` with px, py, pz, E keys | `LVec` |
 | `from_vec` | Create from vector-like object | `vobj` with px, py, pz, E attributes | `LVec` |
 | `boost` | Boost vector to new frame | `bx, by, bz` | `LVec` |
+| `to_frame` | Transform to specified frame | `frame` | `LVec` |
+| `transform_frame` | Transform between frames | `current_frame, target_frame` | `LVec` |
 | `mass` | Get invariant mass | - | `float` |
 | `pt` | Get transverse momentum | - | `float` |
 | `eta` | Get pseudorapidity | - | `float` |
 | `phi` | Get azimuthal angle | - | `float` |
 | `E` | Get energy | - | `float` |
 | `p` | Get total momentum | - | `float` |
+
+### Frame Methods
+
+| Method | Description | Parameters | Returns |
+|--------|-------------|------------|----------|
+| `__init__` | Create a reference frame | `bx, by, bz, name` | `Frame` |
+| `rest` | Create a stationary frame | `name` | `Frame` |
+| `from_lvec` | Create frame in which a vector is at rest | `total_lvec, name` | `Frame` |
+| `center_of_mass` | Create center-of-mass frame from vectors | `lvec_list, name` | `Frame` |
 
 ### 2D Vector (Vector2D) Methods
 
@@ -170,8 +207,9 @@ For detailed documentation and examples, visit our [documentation page](https://
 
 Check out our [examples directory](https://github.com/MohamedElashri/lvec/tree/main/examples) for comprehensive examples including:
 - Basic vector operations
+- Reference frame transformations
 - Decay reconstructions
-- Frame transformations
+- Center-of-mass calculations
 - 2D vector manipulations
 - 3D spatial analysis
 - Advanced selections

--- a/examples/10_reference_frames.py
+++ b/examples/10_reference_frames.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Example demonstrating the use of reference frames in lvec.
+
+This example shows how to:
+1. Create different reference frames
+2. Transform vectors between lab and center-of-mass frames
+3. Work with collision systems
+4. Verify momentum conservation in reference frame transformations
+"""
+
+import numpy as np
+from lvec import LVec, Frame
+
+print("LVEC REFERENCE FRAMES EXAMPLE")
+print("=============================\n")
+
+# Create a simple lab frame (at rest)
+lab_frame = Frame.rest(name="lab")
+print(f"Created lab frame: {lab_frame}")
+
+# Create two colliding particles in the lab frame
+# Particle 1: moving along +z axis
+p1_lab = LVec(px=0.0, py=0.0, pz=20.0, E=25.0)
+# Particle 2: moving along -z axis
+p2_lab = LVec(px=0.0, py=0.0, pz=-15.0, E=20.0)
+
+print("\n=== Particles in lab frame ===")
+print(f"Particle 1: px={p1_lab.px:.3f}, py={p1_lab.py:.3f}, pz={p1_lab.pz:.3f}, E={p1_lab.E:.3f}, mass={p1_lab.mass:.3f}")
+print(f"Particle 2: px={p2_lab.px:.3f}, py={p2_lab.py:.3f}, pz={p2_lab.pz:.3f}, E={p2_lab.E:.3f}, mass={p2_lab.mass:.3f}")
+
+# Calculate the center-of-mass energy
+total_lab = p1_lab + p2_lab
+print(f"\nTotal momentum in lab: px={total_lab.px:.3f}, py={total_lab.py:.3f}, pz={total_lab.pz:.3f}")
+print(f"Total energy in lab: E={total_lab.E:.3f}")
+print(f"Center-of-mass energy (invariant mass): √s={total_lab.mass:.3f}")
+
+# Create a center-of-mass frame for this collision system
+cm_frame = Frame.from_lvec(total_lab, name="center-of-mass")
+print(f"\nCreated CM frame: {cm_frame}")
+
+# Extract beta values, converting to Python scalars if they're arrays
+beta_x = cm_frame.beta_x.item() if hasattr(cm_frame.beta_x, 'item') else cm_frame.beta_x
+beta_y = cm_frame.beta_y.item() if hasattr(cm_frame.beta_y, 'item') else cm_frame.beta_y
+beta_z = cm_frame.beta_z.item() if hasattr(cm_frame.beta_z, 'item') else cm_frame.beta_z
+gamma = cm_frame.gamma.item() if hasattr(cm_frame.gamma, 'item') else cm_frame.gamma
+
+print(f"CM frame velocity (β): ({beta_x:.6f}, {beta_y:.6f}, {beta_z:.6f})")
+print(f"CM frame gamma (γ): {gamma:.6f}")
+print(f"Velocity magnitude |β|: {np.sqrt(beta_x**2 + beta_y**2 + beta_z**2):.6f}")
+
+# Manually calculate velocity to verify
+manual_beta_z = -total_lab.pz / total_lab.E
+print(f"Manual β calculation: {manual_beta_z:.6f}")
+
+# Transform the particles to the center-of-mass frame
+print("\n=== Testing transform_frame method ===")
+p1_cm = p1_lab.transform_frame(lab_frame, cm_frame)
+p2_cm = p2_lab.transform_frame(lab_frame, cm_frame)
+
+print("\n=== Particles in center-of-mass frame ===")
+print(f"Particle 1: px={p1_cm.px:.6f}, py={p1_cm.py:.6f}, pz={p1_cm.pz:.6f}, E={p1_cm.E:.6f}, mass={p1_cm.mass:.6f}")
+print(f"Particle 2: px={p2_cm.px:.6f}, py={p2_cm.py:.6f}, pz={p2_cm.pz:.6f}, E={p2_cm.E:.6f}, mass={p2_cm.mass:.6f}")
+
+# Verify momentum conservation in CM frame
+total_cm = p1_cm + p2_cm
+print(f"\nTotal momentum in CM: px={total_cm.px:.6f}, py={total_cm.py:.6f}, pz={total_cm.pz:.6f}")
+print(f"Total energy in CM: E={total_cm.E:.6f}")
+print(f"Invariant mass in CM: √s={total_cm.mass:.6f}")
+
+# Compare with direct boost method
+print("\n=== Testing direct boost method ===")
+p1_cm_direct = p1_lab.boost(-beta_x, -beta_y, -beta_z)
+p2_cm_direct = p2_lab.boost(-beta_x, -beta_y, -beta_z)
+total_cm_direct = p1_cm_direct + p2_cm_direct
+
+print(f"Direct boost - p1: px={p1_cm_direct.px:.6f}, py={p1_cm_direct.py:.6f}, pz={p1_cm_direct.pz:.6f}")
+print(f"Direct boost - p2: px={p2_cm_direct.px:.6f}, py={p2_cm_direct.py:.6f}, pz={p2_cm_direct.pz:.6f}")
+print(f"Direct boost - Total momentum: px={total_cm_direct.px:.6f}, py={total_cm_direct.py:.6f}, pz={total_cm_direct.pz:.6f}")
+
+# Testing to_frame method
+print("\n=== Testing to_frame method ===")
+p1_cm2 = p1_lab.to_frame(cm_frame)
+p2_cm2 = p2_lab.to_frame(cm_frame)
+total_cm2 = p1_cm2 + p2_cm2
+
+print(f"to_frame - p1: px={p1_cm2.px:.6f}, py={p1_cm2.py:.6f}, pz={p1_cm2.pz:.6f}")
+print(f"to_frame - p2: px={p2_cm2.px:.6f}, py={p2_cm2.py:.6f}, pz={p2_cm2.pz:.6f}")
+print(f"to_frame - Total momentum: px={total_cm2.px:.6f}, py={total_cm2.py:.6f}, pz={total_cm2.pz:.6f}")
+
+# Verify mass invariance
+print("\n=== Mass invariance verification ===")
+print(f"Particle 1 mass - lab: {p1_lab.mass:.6f}, CM: {p1_cm.mass:.6f}, difference: {abs(p1_lab.mass - p1_cm.mass):.9f}")
+print(f"Particle 2 mass - lab: {p2_lab.mass:.6f}, CM: {p2_cm.mass:.6f}, difference: {abs(p2_lab.mass - p2_cm.mass):.9f}")
+print(f"Total mass - lab: {total_lab.mass:.6f}, CM: {total_cm.mass:.6f}, difference: {abs(total_lab.mass - total_cm.mass):.9f}")
+
+# Let's create a decay product in the CM frame
+decay_angle = np.pi/4  # 45 degrees
+decay_p = 10.0  # momentum magnitude
+decay_px = decay_p * np.sin(decay_angle)
+decay_py = 0.0
+decay_pz = decay_p * np.cos(decay_angle)
+decay_mass = 0.5
+decay_E = np.sqrt(decay_px**2 + decay_py**2 + decay_pz**2 + decay_mass**2)
+
+# Create the decay product in the CM frame
+decay_cm = LVec(px=decay_px, py=decay_py, pz=decay_pz, E=decay_E)
+print("\n=== Decay product in center-of-mass frame ===")
+print(f"Decay: px={decay_cm.px:.3f}, py={decay_cm.py:.3f}, pz={decay_cm.pz:.3f}, E={decay_cm.E:.3f}")
+print(f"Decay angle in CM: {np.arctan2(decay_cm.px, decay_cm.pz) * 180/np.pi:.1f} degrees")
+
+# Transform the decay product back to the lab frame
+decay_lab = decay_cm.transform_frame(cm_frame, lab_frame)
+print("\n=== Decay product in lab frame ===")
+print(f"Decay: px={decay_lab.px:.3f}, py={decay_lab.py:.3f}, pz={decay_lab.pz:.3f}, E={decay_lab.E:.3f}")
+print(f"Decay angle in lab: {np.arctan2(decay_lab.px, decay_lab.pz) * 180/np.pi:.1f} degrees")
+print(f"Decay mass invariance: CM={decay_cm.mass:.6f}, lab={decay_lab.mass:.6f}, difference: {abs(decay_cm.mass - decay_lab.mass):.9f}")
+
+# Example using the alternative center_of_mass method
+print("\n=== Frame.center_of_mass method ===")
+cm_frame2 = Frame.center_of_mass([p1_lab, p2_lab], name="cm-alternative")
+print(f"CM frame from particle list: {cm_frame2}")
+beta_matches = (
+    abs(cm_frame.beta_x - cm_frame2.beta_x) < 1e-10 and 
+    abs(cm_frame.beta_y - cm_frame2.beta_y) < 1e-10 and 
+    abs(cm_frame.beta_z - cm_frame2.beta_z) < 1e-10
+)
+print(f"Velocities match original CM frame: {beta_matches}")

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,7 +60,7 @@ mask = (muon1.pt > 20) & (muon2.pt > 20) & \
 muon1_selected = muon1[mask]
 ```
 
-### 4. Reference Frames (`04_boost_frame.py`)
+### 4. Boost Frame (`04_boost_frame.py`)
 Shows advanced operations:
 - Calculating boost vectors
 - Performing Lorentz boosts
@@ -121,18 +121,6 @@ h2 = LVec(h2_px, h2_py, h2_pz, calculate_energy(h2_px, h2_py, h2_pz))
 # Calculate two-body invariant masses
 m12 = (h1 + h2).mass  # Invariant mass of particles 1 and 2
 ```
-
-### 9. Cache Performance (`09_cache_performance.py`)
-Demonstrates how to:
-- Analyze cache hit ratio
-- Measure performance improvements due to caching
-
-```python
-# Measure cache hit ratio
-cache_hit_ratio = vec.cache_hit_ratio
-print(f"Cache hit ratio: {cache_hit_ratio:.2f}")
-```
-
 #### Dependencies
 Additional dependencies required for this example:
 ```bash
@@ -154,7 +142,52 @@ This will:
 1. Download the LHCb data file
 2. Calculate two-body invariant masses
 3. Create publication-style mass distribution plots
-4. Save plots as 'mass_distributions.pdf'
+
+
+
+### 9. Cache Performance (`09_cache_performance.py`)
+Demonstrates how to:
+- Analyze cache hit ratio
+- Measure performance improvements due to caching
+
+```python
+# Measure cache hit ratio
+cache_hit_ratio = vec.cache_hit_ratio
+print(f"Cache hit ratio: {cache_hit_ratio:.2f}")
+```
+
+### 10. Reference Frames (`10_reference_frames.py`)
+Demonstrates how to:
+- Create and work with reference frames
+- Transform particles between frames
+- Verify momentum conservation in the center-of-mass frame
+- Check if invariant quantities are preserved across transformations
+
+```python
+# Create a center-of-mass frame
+cm_frame = Frame.from_lvec(total, name="center-of-mass")
+
+# Transform particles to center-of-mass frame
+p1_cm = p1.transform_frame(lab_frame, cm_frame)
+p2_cm = p2.transform_frame(lab_frame, cm_frame)
+
+# Verify total momentum is zero in CM frame
+total_cm = p1_cm + p2_cm
+print(f"Total momentum in CM: px={total_cm.px:.6f}, py={total_cm.py:.6f}, pz={total_cm.pz:.6f}")
+```
+
+Sample output:
+```
+=== Particles in center-of-mass frame ===
+Particle 1: px=0.000000, py=0.000000, pz=17.329527, E=22.919697, mass=15.000000
+Particle 2: px=0.000000, py=0.000000, pz=-17.329527, E=21.801663, mass=13.228757
+
+Total momentum in CM: px=0.000000, py=0.000000, pz=0.000000
+Total energy in CM: E=44.721360
+Invariant mass in CM: √s=44.721360
+```
+
+
 
 ## Running the Examples
 
@@ -166,6 +199,7 @@ python 03_advanced_selections.py
 python 04_boost_frame.py
 python 08_lhcb_data.py
 python 09_cache_performance.py
+python 10_reference_frames.py
 ```
 
 ## Expected Output

--- a/lvec/__init__.py
+++ b/lvec/__init__.py
@@ -2,6 +2,7 @@
 from .lvec import LVec
 from .vectors import Vec2D as Vector2D, Vec3D as Vector3D
 from .exceptions import ShapeError
+from .frame import Frame
 
-__all__ = ['LVec', 'Vector2D', 'Vector3D', 'ShapeError']
+__all__ = ['LVec', 'Vector2D', 'Vector3D', 'Frame', 'ShapeError']
 __version__ = '0.1.3'

--- a/lvec/frame.py
+++ b/lvec/frame.py
@@ -1,0 +1,208 @@
+import numpy as np
+from .backends import (to_np, to_ak, is_ak, is_np, 
+                      backend_sqrt, backend_where)
+from .utils import ensure_array, check_shapes
+from .exceptions import InputError, BackendError, DependencyError
+
+class Frame:
+    """
+    Represents a particular reference frame in which LVecs can be expressed.
+    
+    A Frame is characterized by a 3-velocity (beta_x, beta_y, beta_z) that represents
+    the velocity needed to boost from the universal rest frame to this frame.
+    
+    Attributes:
+        beta_x, beta_y, beta_z: Components of velocity in units of c
+        name: Optional human-readable label (e.g. 'lab', 'cm', etc.)
+    """
+
+    def __init__(self, bx, by, bz, name=None):
+        """
+        Create a frame from a 3-velocity (β⃗).
+
+        Parameters
+        ----------
+        bx, by, bz : float or array_like
+            Components of velocity in units of c
+        name : str, optional
+            Optional human-readable label (e.g. 'lab', 'cm', etc.)
+            
+        Raises:
+            InputError: If boost velocity is >= speed of light
+            BackendError: If there's an issue with the backend operations
+        """
+        try:
+            # Check if all inputs are scalars
+            all_scalars = all(isinstance(b, (float, int)) for b in [bx, by, bz])
+            
+            if all_scalars:
+                # For scalar inputs, keep them as scalars
+                self._beta_x, self._beta_y, self._beta_z = bx, by, bz
+                self._lib = 'np'  # Default to NumPy for scalars
+            else:
+                # For array inputs, use ensure_array
+                dummy = bz  # Dummy value for the 4th parameter required by ensure_array
+                self._beta_x, self._beta_y, self._beta_z, _, self._lib = ensure_array(bx, by, bz, dummy)
+                # Validate shape consistency
+                check_shapes(self._beta_x, self._beta_y, self._beta_z, self._lib)
+            
+            # Validate that velocity is less than speed of light
+            b2 = self._beta_x**2 + self._beta_y**2 + self._beta_z**2
+            
+            if isinstance(b2, (float, int)):
+                if b2 >= 1:
+                    raise InputError("boost velocity", f"√{b2}", "Must be < 1 (speed of light)")
+            else:
+                if self._lib == 'np' and (b2 >= 1).any():
+                    raise InputError("boost velocity", "array", 
+                                    "All values must be < 1 (speed of light)")
+                elif self._lib == 'ak':
+                    try:
+                        import awkward as ak
+                    except ImportError:
+                        raise DependencyError("awkward", "pip install awkward")
+                    if ak.any(b2 >= 1):
+                        raise InputError("boost velocity", "array", 
+                                        "All values must be < 1 (speed of light)")
+                        
+        except Exception as e:
+            if isinstance(e, (InputError, DependencyError)):
+                raise
+            raise BackendError("Frame initialization", self._lib, str(e))
+            
+        self.name = name if name else "unnamed"
+
+    @classmethod
+    def rest(cls, name="lab"):
+        """
+        Return a frame with no boost (the 'rest' frame).
+
+        Parameters
+        ----------
+        name : str
+            Optional label for the frame
+
+        Returns
+        -------
+        Frame
+            Frame object with zero velocity
+        """
+        return cls(0.0, 0.0, 0.0, name=name)
+
+    @classmethod
+    def from_lvec(cls, total_lvec, name="cm"):
+        """
+        Compute the frame in which total_lvec is at rest (center-of-mass frame).
+
+        Parameters
+        ----------
+        total_lvec : LVec
+            The sum of the 4-vectors for the system
+        name : str
+            Name for the frame
+
+        Returns
+        -------
+        Frame
+            Frame in which total_lvec is at rest
+            
+        Raises:
+            InputError: If energy component is zero
+            BackendError: If there's an issue with the backend operations
+        """
+        # Get the momentum and energy components
+        px, py, pz = total_lvec.px, total_lvec.py, total_lvec.pz
+        E = total_lvec.E
+        
+        # Get the library type from total_lvec for consistent handling
+        lib = total_lvec._lib
+        
+        # Avoid dividing by zero if E==0
+        if isinstance(E, (float, int)):
+            if E == 0:
+                raise InputError("Energy", E, 
+                                "Cannot create a rest frame for a system with zero energy")
+            # Calculate the velocity needed to boost to the CM frame
+            # This is the negative of the total momentum divided by total energy
+            bx, by, bz = -px / E, -py / E, -pz / E
+        else:
+            # Array case - handle with care using the appropriate backend
+            if lib == 'np':
+                if np.any(E == 0):
+                    raise InputError("Energy", "array",
+                                    "Cannot create rest frames for systems with zero energy")
+                bx, by, bz = -px / E, -py / E, -pz / E
+            elif lib == 'ak':
+                try:
+                    import awkward as ak
+                except ImportError:
+                    raise DependencyError("awkward", "pip install awkward")
+                if ak.any(E == 0):
+                    raise InputError("Energy", "array",
+                                    "Cannot create rest frames for systems with zero energy")
+                bx, by, bz = -px / E, -py / E, -pz / E
+
+        return cls(bx, by, bz, name=name)
+
+    @classmethod
+    def center_of_mass(cls, lvec_list, name="cm"):
+        """
+        Convenience method to compute the center-of-mass frame for a collection of LVecs.
+
+        Parameters
+        ----------
+        lvec_list : list or iterable of LVec
+            List of LVecs that make up the system
+        name : str
+            Frame name
+
+        Returns
+        -------
+        Frame
+            The center-of-mass frame for the system
+            
+        Raises:
+            ValueError: If lvec_list is empty
+            TypeError: If items in lvec_list are not LVec objects
+        """
+        if not lvec_list:
+            raise ValueError("Cannot create a center-of-mass frame from an empty list")
+            
+        # Import here to avoid circular import
+        from .lvec import LVec
+        
+        # Ensure all items are LVec objects
+        if not all(isinstance(v, LVec) for v in lvec_list):
+            raise TypeError("All items in lvec_list must be LVec objects")
+            
+        # Sum all LVecs to get the total 4-momentum
+        total = None
+        for vec in lvec_list:
+            total = vec if total is None else (total + vec)
+            
+        return cls.from_lvec(total, name=name)
+
+    @property
+    def beta_x(self):
+        """X-component of the boost velocity in units of c."""
+        return self._beta_x
+
+    @property
+    def beta_y(self):
+        """Y-component of the boost velocity in units of c."""
+        return self._beta_y
+
+    @property
+    def beta_z(self):
+        """Z-component of the boost velocity in units of c."""
+        return self._beta_z
+        
+    @property
+    def gamma(self):
+        """Lorentz factor γ = 1/√(1-β²) for this frame."""
+        b2 = self._beta_x**2 + self._beta_y**2 + self._beta_z**2
+        return 1.0 / backend_sqrt(1.0 - b2, self._lib)
+        
+    def __repr__(self):
+        """String representation of the Frame."""
+        return f"Frame('{self.name}', β=({self._beta_x}, {self._beta_y}, {self._beta_z}))"

--- a/lvec/tests/test_frame.py
+++ b/lvec/tests/test_frame.py
@@ -168,8 +168,7 @@ def test_lvec_transform_frame():
     
     assert abs(total_cm.px) < 1e-10
     assert abs(total_cm.py) < 1e-10
-    # Temporarily comment out failing assertion for debugging
-    # assert abs(total_cm.pz) < 1e-10  
+    assert abs(total_cm.pz) < 1e-10
     print(f"Total pz in CM frame: {total_cm.pz}")
     
     # Test invariant mass

--- a/lvec/tests/test_frame.py
+++ b/lvec/tests/test_frame.py
@@ -1,0 +1,264 @@
+import pytest
+import numpy as np
+import awkward as ak
+from lvec import LVec, Frame
+from lvec.exceptions import InputError
+
+def test_frame_rest():
+    """Test creating a rest frame."""
+    frame = Frame.rest(name="test")
+    assert frame.beta_x == 0.0
+    assert frame.beta_y == 0.0
+    assert frame.beta_z == 0.0
+    assert frame.name == "test"
+    assert frame.gamma == 1.0
+
+def test_frame_init():
+    """Test Frame initialization with explicit velocity components."""
+    # Test with scalar values
+    bx, by, bz = 0.1, 0.2, 0.3
+    frame = Frame(bx, by, bz, name="test_frame")
+    
+    assert frame.beta_x == 0.1
+    assert frame.beta_y == 0.2
+    assert frame.beta_z == 0.3
+    assert frame.name == "test_frame"
+    
+    # Test gamma calculation
+    b2 = bx**2 + by**2 + bz**2
+    expected_gamma = 1 / np.sqrt(1 - b2)
+    assert abs(frame.gamma - expected_gamma) < 1e-10
+
+def test_frame_velocity_limit():
+    """Test that velocities >= c raise an error."""
+    # Test with velocity at light speed
+    with pytest.raises(InputError):
+        Frame(0.0, 0.0, 1.0)
+    
+    # Test with velocity greater than light speed
+    with pytest.raises(InputError):
+        Frame(0.0, 0.0, 1.1)
+    
+    # Test with combined velocity components exceeding c
+    with pytest.raises(InputError):
+        Frame(0.7, 0.7, 0.3)  # sqrt(0.7^2 + 0.7^2 + 0.3^2) > 1
+
+def test_frame_from_lvec():
+    """Test creating a frame from an LVec."""
+    # Create a simple 4-vector
+    lvec = LVec(px=0.0, py=0.0, pz=5.0, E=10.0)
+    
+    # Create frame from the 4-vector
+    frame = Frame.from_lvec(lvec, name="rest_frame")
+    
+    # The velocity should be -p/E
+    assert abs(frame.beta_x - (-lvec.px / lvec.E)) < 1e-10
+    assert abs(frame.beta_y - (-lvec.py / lvec.E)) < 1e-10
+    assert abs(frame.beta_z - (-lvec.pz / lvec.E)) < 1e-10
+    
+    # Test with a more complex 4-vector
+    lvec2 = LVec(px=1.0, py=2.0, pz=3.0, E=10.0)
+    frame2 = Frame.from_lvec(lvec2)
+    
+    assert abs(frame2.beta_x - (-0.1)) < 1e-10
+    assert abs(frame2.beta_y - (-0.2)) < 1e-10
+    assert abs(frame2.beta_z - (-0.3)) < 1e-10
+
+def test_frame_from_lvec_zero_energy():
+    """Test that creating a frame from a zero-energy LVec raises an error."""
+    lvec = LVec(px=0.0, py=0.0, pz=0.0, E=0.0)
+    with pytest.raises(InputError):
+        Frame.from_lvec(lvec)
+
+def test_frame_center_of_mass():
+    """Test creating a center-of-mass frame from a list of LVecs."""
+    # Create two particles
+    p1 = LVec(px=0.0, py=0.0, pz=20.0, E=25.0)
+    p2 = LVec(px=0.0, py=0.0, pz=-15.0, E=20.0)
+    
+    # Create CM frame
+    cm_frame = Frame.center_of_mass([p1, p2], name="cm")
+    
+    # Calculate expected velocity (negative of total momentum / total energy)
+    total = p1 + p2
+    expected_bx = -total.px / total.E
+    expected_by = -total.py / total.E
+    expected_bz = -total.pz / total.E
+    
+    assert abs(cm_frame.beta_x - expected_bx) < 1e-10
+    assert abs(cm_frame.beta_y - expected_by) < 1e-10
+    assert abs(cm_frame.beta_z - expected_bz) < 1e-10
+    
+    # Test with empty list
+    with pytest.raises(ValueError):
+        Frame.center_of_mass([])
+    
+    # Test with non-LVec object
+    with pytest.raises(TypeError):
+        Frame.center_of_mass([p1, "not an LVec"])
+
+def test_lvec_to_frame():
+    """Test transforming a vector to a specific frame."""
+    # Create a particle at rest
+    v = LVec(px=0.0, py=0.0, pz=0.0, E=1.0)
+    
+    # Create a moving frame
+    bz = 0.5
+    frame = Frame(0.0, 0.0, bz, name="moving_frame")
+    
+    # Transform the particle to the moving frame
+    v_frame = v.to_frame(frame)
+    
+    # In the moving frame, the particle should have momentum opposing the frame's motion
+    gamma = 1 / np.sqrt(1 - bz**2)
+    assert abs(v_frame.E - gamma) < 1e-10
+    assert abs(v_frame.pz - (-gamma * bz)) < 1e-10
+    assert abs(v_frame.px) < 1e-10
+    assert abs(v_frame.py) < 1e-10
+    
+    # Try a more complex case
+    v2 = LVec(px=1.0, py=2.0, pz=3.0, E=10.0)
+    frame2 = Frame(0.1, 0.2, 0.3)
+    v2_frame = v2.to_frame(frame2)
+    
+    # Mass should be invariant
+    assert abs(v2.mass - v2_frame.mass) < 1e-10
+
+def test_lvec_transform_frame():
+    """Test transforming a vector between two arbitrary frames."""
+    # Create a vector in lab frame
+    v_lab = LVec(px=0.0, py=0.0, pz=10.0, E=15.0)
+    
+    # Create lab and CM frames
+    lab_frame = Frame.rest(name="lab")
+    
+    # Create another particle for a collision
+    v2_lab = LVec(px=0.0, py=0.0, pz=-5.0, E=10.0)
+    total = v_lab + v2_lab
+    
+    print(f"\nLab frame particles:")
+    print(f"p1: px={v_lab.px}, py={v_lab.py}, pz={v_lab.pz}, E={v_lab.E}")
+    print(f"p2: px={v2_lab.px}, py={v2_lab.py}, pz={v2_lab.pz}, E={v2_lab.E}")
+    print(f"Total: px={total.px}, py={total.py}, pz={total.pz}, E={total.E}")
+    
+    cm_frame = Frame.from_lvec(total, name="cm")
+    print(f"CM frame velocity: βx={cm_frame.beta_x}, βy={cm_frame.beta_y}, βz={cm_frame.beta_z}")
+    
+    # Transform v_lab to CM frame directly using boost
+    beta_z = -total.pz / total.E  # Velocity of CM frame
+    v_cm_direct = v_lab.boost(0, 0, beta_z)
+    print(f"Direct boost: px={v_cm_direct.px}, py={v_cm_direct.py}, pz={v_cm_direct.pz}, E={v_cm_direct.E}")
+    
+    # Transform using transform_frame method
+    v_cm = v_lab.transform_frame(lab_frame, cm_frame)
+    print(f"transform_frame: px={v_cm.px}, py={v_cm.py}, pz={v_cm.pz}, E={v_cm.E}")
+    
+    # The total momentum in CM frame should be zero after transforming both particles
+    v2_cm = v2_lab.transform_frame(lab_frame, cm_frame)
+    print(f"p2 in CM: px={v2_cm.px}, py={v2_cm.py}, pz={v2_cm.pz}, E={v2_cm.E}")
+    
+    total_cm = v_cm + v2_cm
+    print(f"Total in CM: px={total_cm.px}, py={total_cm.py}, pz={total_cm.pz}, E={total_cm.E}")
+    
+    # Also try the to_frame method
+    v_cm2 = v_lab.to_frame(cm_frame)
+    v2_cm2 = v2_lab.to_frame(cm_frame)
+    total_cm2 = v_cm2 + v2_cm2
+    print(f"Using to_frame - Total in CM: px={total_cm2.px}, py={total_cm2.py}, pz={total_cm2.pz}, E={total_cm2.E}")
+    
+    assert abs(total_cm.px) < 1e-10
+    assert abs(total_cm.py) < 1e-10
+    # Temporarily comment out failing assertion for debugging
+    # assert abs(total_cm.pz) < 1e-10  
+    print(f"Total pz in CM frame: {total_cm.pz}")
+    
+    # Test invariant mass
+    assert abs(v_lab.mass - v_cm.mass) < 1e-10
+    assert abs(v2_lab.mass - v2_cm.mass) < 1e-10
+    assert abs(total.mass - total_cm.mass) < 1e-10
+
+def test_frame_with_arrays():
+    """Test Frame with array inputs."""
+    # Create a batch of velocities
+    bx = np.array([0.1, 0.2, 0.3])
+    by = np.array([0.0, 0.0, 0.0])
+    bz = np.array([0.0, 0.0, 0.0])
+    
+    # Create frame with array velocities
+    frame = Frame(bx, by, bz)
+    
+    # Check that array shapes are preserved
+    assert frame.beta_x.shape == bx.shape
+    assert frame.beta_y.shape == by.shape
+    assert frame.beta_z.shape == bz.shape
+    
+    # Check gamma calculation with arrays
+    expected_gamma = 1 / np.sqrt(1 - bx**2)
+    np.testing.assert_allclose(frame.gamma, expected_gamma)
+    
+    # Test with velocities exceeding c in some elements
+    bx_invalid = np.array([0.1, 1.1, 0.3])
+    with pytest.raises(InputError):
+        Frame(bx_invalid, by, bz)
+
+def test_frame_with_awkward_arrays():
+    """Test Frame with Awkward array inputs."""
+    # Skip if awkward is not available
+    pytest.importorskip("awkward")
+    
+    # Create a batch of velocities as Awkward arrays
+    bx = ak.Array([0.1, 0.2, 0.3])
+    by = ak.Array([0.0, 0.0, 0.0])
+    bz = ak.Array([0.0, 0.0, 0.0])
+    
+    # Create frame with Awkward array velocities
+    frame = Frame(bx, by, bz)
+    
+    # Check library type
+    assert frame._lib == 'ak'
+    
+    # Test transforming an LVec with Awkward arrays
+    px = ak.Array([1.0, 2.0, 3.0])
+    py = ak.Array([0.0, 0.0, 0.0])
+    pz = ak.Array([0.0, 0.0, 0.0])
+    E = ak.Array([2.0, 3.0, 4.0])
+    
+    v = LVec(px, py, pz, E)
+    v_frame = v.to_frame(frame)
+    
+    # Check shapes are preserved
+    assert len(v_frame.px) == len(px)
+    assert len(v_frame.py) == len(py)
+    assert len(v_frame.pz) == len(pz)
+    assert len(v_frame.E) == len(E)
+
+def test_invariant_quantities():
+    """Test that physics invariants are preserved under frame transformations."""
+    # Create two particles in the lab frame
+    p1_lab = LVec(px=0.0, py=0.0, pz=20.0, E=25.0)
+    p2_lab = LVec(px=0.0, py=0.0, pz=-15.0, E=20.0)
+    
+    # Create lab and CM frames
+    lab_frame = Frame.rest()
+    cm_frame = Frame.center_of_mass([p1_lab, p2_lab])
+    
+    # Transform to CM frame
+    p1_cm = p1_lab.transform_frame(lab_frame, cm_frame)
+    p2_cm = p2_lab.transform_frame(lab_frame, cm_frame)
+    
+    # Test invariant quantities
+    
+    # 1. Individual masses
+    assert abs(p1_lab.mass - p1_cm.mass) < 1e-10
+    assert abs(p2_lab.mass - p2_cm.mass) < 1e-10
+    
+    # 2. Total invariant mass (CM energy)
+    total_lab = p1_lab + p2_lab
+    total_cm = p1_cm + p2_cm
+    assert abs(total_lab.mass - total_cm.mass) < 1e-10
+    
+    # 3. Scalar products between 4-vectors
+    # p1 · p2 = E1*E2 - px1*px2 - py1*py2 - pz1*pz2
+    dot_lab = p1_lab.E * p2_lab.E - p1_lab.px * p2_lab.px - p1_lab.py * p2_lab.py - p1_lab.pz * p2_lab.pz
+    dot_cm = p1_cm.E * p2_cm.E - p1_cm.px * p2_cm.px - p1_cm.py * p2_cm.py - p1_cm.pz * p2_cm.pz
+    assert abs(dot_lab - dot_cm) < 1e-10


### PR DESCRIPTION
This PR introduce a new `Frame` class providing a comprehensive framework for relativistic reference frame transformations. 


This will introduce the following methods for constructing frames

- `Frame.rest()`: Create a stationary reference frame
- `Frame.from_lvec()`: Create a frame in which a specified Lorentz vector is at rest
- `Frame.center_of_mass()`: Create a center-of-mass frame from a collection of particles

And the following methods for frames transformations 

- `LVec.to_frame()`: Transform a vector directly to a specified reference frame
- `LVec.transform_frame()`: Transform a vector between two explicit reference frames

And updating the docs to include the new frame with example about how it can be used. 